### PR TITLE
add explicit winit dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ num = "0.4.*"
 [dev-dependencies]
 bevy = { version = "0.11.0", default-features = false, features = ["bevy_asset", "bevy_winit", "png"] }
 bevy-inspector-egui = { version = "0.19.0", default-features = false }
+winit = "0.28.*"
 
 [lib]
 name = "bevy_fast_tilemap"


### PR DESCRIPTION
Otherwise, examples fail to run on Fedora Linux, with:

```
error: The platform you're compiling for is not supported by winit
```